### PR TITLE
fix error in rails 6

### DIFF
--- a/lib/active_support/cache/dynamo_store.rb
+++ b/lib/active_support/cache/dynamo_store.rb
@@ -73,7 +73,7 @@ module ActiveSupport
         true
       end
 
-      def delete_entry(name, _options)
+      def delete_entry(name, _options = nil)
         dynamodb_client.delete_item(
           key: { hash_key => name },
           table_name: table_name


### PR DESCRIPTION
using with rails 6.1.4.1, it occurs 
```
in `delete_entry': wrong number of arguments (given 1, expected 2) (ArgumentError)
```