### PR TITLE
add handler for DynamoDB error

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -10,4 +10,4 @@
 # Configuration parameters: CountComments, CountAsOne, ExcludedMethods, IgnoredMethods.
 # IgnoredMethods: refine
 Metrics/BlockLength:
-  Max: 90
+  Max: 150

--- a/spec/lib/active_support/cache/dynamo_store_spec.rb
+++ b/spec/lib/active_support/cache/dynamo_store_spec.rb
@@ -67,6 +67,30 @@ RSpec.describe ActiveSupport::Cache::DynamoStore do
         expect { store.delete(SecureRandom.uuid) }.not_to raise_error
       end
     end
+
+    describe 'throw exception' do
+      let(:store) do
+        ActiveSupport::Cache::DynamoStore.new(
+          table_name: "#{standard_table_name}-invalid",
+          dynamo_client: client,
+        )
+      end
+
+      it 'write error handle' do
+        expect(store.error_handler).to receive(:call).with(method: :write_entry, returning: false, exception: kind_of(Aws::DynamoDB::Errors::ServiceError))
+        store.write(key, 'test')
+      end
+
+      it 'read error handle' do
+        expect(store.error_handler).to receive(:call).with(method: :read_entry, returning: nil, exception: kind_of(Aws::DynamoDB::Errors::ServiceError))
+        store.read(key)
+      end
+
+      it 'delete error handle' do
+        expect(store.error_handler).to receive(:call).with(method: :delete_entry, returning: nil, exception: kind_of(Aws::DynamoDB::Errors::ServiceError))
+        store.delete(key)
+      end
+    end
   end
 
   context 'using a custom configuration' do


### PR DESCRIPTION
This pull request aims to enhance the error handling mechanism by introducing new error_handler field in constructor. The primary goal is to increase the stability of Rails.cache, simplify debugging, and improve the overall user experience.